### PR TITLE
Add --yes flag to auto-accept and display AI-generated commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ To automatically accept the first generated commit message without any interacti
 gemcommits --yes # or -y
 ```
 
+> **Note:** When using `--yes`, the committed message will be displayed in the CLI output for your reference.
+
 #### Generate multiple recommendations
 
 Sometimes the recommended commit message isn't the best so you want it to generate a few to pick from. You can generate multiple commit messages at once by passing in the `--generate <i>` flag, where 'i' is the number of generated messages:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <h1 align="center">Gem Commits</h1>
   </div>
 	<p>A CLI that writes your Git commit messages for you with AI. Never write a commit message again. This is a fork of <a href="https://github.com/Nutlope/aicommits">aicommits</a>, which was modified to use Gemini instead of OpenAI. Huge thanks go to them for open-sourcing their work.</p>
-	<!-- <a href="https://www.npmjs.com/package/gemcommits"><img src="https://img.shields.io/npm/v/aicommits" alt="Current version"></a> -->
+	<!-- <a href="https://www.npmjs.com/package/gemcommits"><img src="https://img.shields.io/npm/v/gemcommits" alt="Current version"></a> -->
 </div>
 
 ---
@@ -65,6 +65,14 @@ gemcommits --all # or -a
 ```
 
 > 👉 **Tip:** Use the `gemc` alias if `gemcommits` is too long for you.
+
+#### Auto-accepting the commit message
+
+To automatically accept the first generated commit message without any interactive prompt, you can use the `--yes` flag:
+
+```sh
+gemcommits --yes # or -y
+```
 
 #### Generate multiple recommendations
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <h1 align="center">Gem Commits</h1>
   </div>
 	<p>A CLI that writes your Git commit messages for you with AI. Never write a commit message again. This is a fork of <a href="https://github.com/Nutlope/aicommits">aicommits</a>, which was modified to use Gemini instead of OpenAI. Huge thanks go to them for open-sourcing their work.</p>
-	<!-- <a href="https://www.npmjs.com/package/gemcommits"><img src="https://img.shields.io/npm/v/gemcommits" alt="Current version"></a> -->
+	<a href="https://www.npmjs.com/package/gemcommits"><img src="https://img.shields.io/npm/v/gemcommits" alt="Current version"></a>
 </div>
 
 ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,13 @@ cli(
 				description: 'Type of commit message to generate',
 				alias: 't',
 			},
+			yes: {
+				type: Boolean,
+				description:
+					'Automatically accept the first generated commit message',
+				alias: 'y',
+				default: false,
+			},
 		},
 
 		commands: [configCommand, hookCommand],
@@ -61,6 +68,7 @@ cli(
 				argv.flags.exclude,
 				argv.flags.all,
 				argv.flags.type,
+				argv.flags.yes,
 				rawArgv
 			);
 		}

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -22,47 +22,48 @@ export default async (
 	excludeFiles: string[],
 	stageAll: boolean,
 	commitType: string | undefined,
+	autoAccept: boolean | undefined,
 	rawArgv: string[]
 ) =>
 	(async () => {
-		intro(bgCyan(black(' gemcommits ')));
-		await assertGitRepo();
+		intro(bgCyan(black(' gemcommits ')))
+		await assertGitRepo()
 
-		const detectingFiles = spinner();
+		const detectingFiles = spinner()
 
 		if (stageAll) {
 			// This should be equivalent behavior to `git commit --all`
-			await execa('git', ['add', '--update']);
+			await execa('git', ['add', '--update'])
 		}
 
-		detectingFiles.start('Detecting staged files');
-		const staged = await getStagedDiff(excludeFiles);
+		detectingFiles.start('Detecting staged files')
+		const staged = await getStagedDiff(excludeFiles)
 
 		if (!staged) {
-			detectingFiles.stop('Detecting staged files');
+			detectingFiles.stop('Detecting staged files')
 			throw new KnownError(
 				'No staged changes found. Stage your changes manually, or automatically stage all changes with the `--all` flag.'
-			);
+			)
 		}
 
 		detectingFiles.stop(
 			`${getDetectedMessage(staged.files)}:\n${staged.files
 				.map((file) => `     ${file}`)
 				.join('\n')}`
-		);
+		)
 
-		const { env } = process;
+		const { env } = process
 		const config = await getConfig({
 			GEMINI_KEY: env.GEMINI_KEY || env.GEMINI_API_KEY,
 			proxy:
 				env.https_proxy || env.HTTPS_PROXY || env.http_proxy || env.HTTP_PROXY,
 			generate: generate?.toString(),
 			type: commitType?.toString(),
-		});
+		})
 
-		const s = spinner();
-		s.start('The AI is analyzing your changes');
-		let messages: string[];
+		const s = spinner()
+		s.start('The AI is analyzing your changes')
+		let messages: string[]
 		try {
 			messages = await generateCommitMessage(
 				config.GEMINI_KEY,
@@ -73,39 +74,42 @@ export default async (
 				config['max-length'],
 				config.type,
 				config.timeout
-			);
+			)
 		} finally {
-			s.stop('Changes analyzed');
+			s.stop('Changes analyzed')
 		}
 
 		if (messages.length === 0) {
-			throw new KnownError('No commit messages were generated. Try again.');
+			throw new KnownError('No commit messages were generated. Try again.')
 		}
 
-		let message: string;
-		if (messages.length === 1) {
-			[message] = messages;
+		let message: string
+		if (autoAccept) {
+			[message] = messages
+		} else if (messages.length === 1) {
+			[message] = messages
 			const confirmed = await confirm({
 				message: `Use this commit message?\n\n   ${message}\n`,
-			});
+			})
 
 			if (!confirmed || isCancel(confirmed)) {
-				outro('Commit cancelled');
-				return;
+				outro('Commit cancelled')
+				return
 			}
 		} else {
 			const selected = await select({
 				message: `Pick a commit message to use: ${dim('(Ctrl+c to exit)')}`,
 				options: messages.map((value) => ({ label: value, value })),
-			});
+			})
 
 			if (isCancel(selected)) {
-				outro('Commit cancelled');
-				return;
+				outro('Commit cancelled')
+				return
 			}
 
-			message = selected as string;
+			message = selected as string
 		}
+
 
 		await execa('git', ['commit', '-m', message, ...rawArgv]);
 

--- a/src/commands/aicommits.ts
+++ b/src/commands/aicommits.ts
@@ -113,7 +113,11 @@ export default async (
 
 		await execa('git', ['commit', '-m', message, ...rawArgv]);
 
-		outro(`${green('✔')} Successfully committed!`);
+		if (autoAccept) {
+			outro(`${green('✔')} Successfully committed with message:\n\n   ${message}`);
+		} else {
+			outro(`${green('✔')} Successfully committed!`);
+		}
 	})().catch((error) => {
 		outro(`${red('✖')} ${error.message}`);
 		handleCliError(error);


### PR DESCRIPTION
## Summary
This PR introduces a new `--yes (-y)` flag to the CLI, allowing users to automatically accept the first AI-generated commit message and commit it without any interactive prompt. When this flag is used, the committed message is also displayed in the CLI output for user reference.

Closes #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI flag `--yes` (or `-y`) to automatically accept the first generated commit message without prompting for confirmation.
  * When using the auto-accept flag, the committed message is displayed in the CLI output.

* **Documentation**
  * Updated the README to document the new auto-accept feature and correct the badge URL to the new package name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->